### PR TITLE
Stop running apps unnecessarily 

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = function (Domain, libs) {
                                             };
                                         });
                                 }
-                                else if (options.statusCode == 504) {
+                                else if (options.statusCode == 503) {
                                     console.error('No application error handler.');
                                 }
                                 else {

--- a/index.js
+++ b/index.js
@@ -81,10 +81,8 @@ module.exports = function (Domain, libs) {
                             ctxt.error('Invalid redirect route: ' + typeof redirectRoute);
                             return;
                         }
-                        if (currentHash() === newHash) {
-                            window.history.replaceState(null, null, '#' + redirectRoute.join('/'));
-                            d.send(['navigate'].concat(redirectRoute), []);
-                        }
+                        window.history.replaceState(null, null, '#' + redirectRoute.join('/'));
+                        return d.send(['navigate'].concat(redirectRoute), []);
                     }
                     else {
                         var message = '' + options.statusCode + ' : ' + body;

--- a/test/mock-window.js
+++ b/test/mock-window.js
@@ -89,10 +89,12 @@ module.exports = function (startURL) {
                     if (v[0] === '#') {
                         v = v.slice(1);
                     }
-                    var newLocation = parseLocation(history[history.length - 1], '#' + v);
-                    history.push(newLocation);
-                    setLocation(newLocation);
-                    events.emit('hashchange');
+                    process.nextTick(function () {
+                        var newLocation = parseLocation(history[history.length - 1], '#' + v);
+                        history.push(newLocation);
+                        setLocation(newLocation);
+                        events.emit('hashchange');
+                    });
                 }
                 , get: function () {
                     return locationObj._hash;


### PR DESCRIPTION
If the user navigates before an app has loaded, there is no reason to load it.

Also, refactor state simulation in tests to handle this correctly.
